### PR TITLE
Mysql existing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Axway - API Gateway Helm Chart
+# Axway - API Gateway Helm Chart
 
 As with many kubernetes solutions, we use helm to manage the deployment of the API Gateway infrastructure. Helm is a very powerful tool that uses a management structure, that it refers to as charts, to define the resources you want to deploy to your kubernetes cluster. These resources can then be parameterized to enable easy configuration and customization from a single location. Charts can also be divided into subcharts in the event that some resources may only need to be deployed under certain criteria. While helm notably simplifies the deployment and management of artifacts in a kubernetes cluster, some familiarity with kubernetes, it's basic tools and the resources it uses would be desirable in order to correctly understand what a helm chart does and to be able to troubleshoot in the event of any issues.
 
 The Helm Chart provided here contains all the kubernetes manifest files required to run the API Gateway in Kubernetes. This includes deployment of Admin Node Manager, API Manager UI and API Gateway Traffic containers as well as configuring an external MySQL database should it be present. These charts should be able to deploy on most clusters regardless of where it is running. However these charts do not include artifacts such as LoadBalancers or Ingress Controllers that allow external connection to the cluster. This is because these artifacts are different depending on the platform you are running on. Port-forwarding can be configured to validate the services and cluster without these external connections being configured.
 
-##Prerequisites
+## Prerequisites
 As stated some familiarity with kubernetes tools is required as well as knowledge of the gateway setup such as FED configuration. 
 - Kubectl installed
 - Kubernetes cluster built - we use kops to build our clusters in AWS but this chart should work on any cluster, regardless of how it should be built.
@@ -14,7 +14,7 @@ As stated some familiarity with kubernetes tools is required as well as knowledg
 - Cassandra Cluster configured
 - (Optional) MySQL Configured
 
-###values.yaml
+### values.yaml
 Most, if not all of the variables you need to set are defined in values.yaml. This simplifies configuration as it should allow all changes to be made in a single location. The defaults for most of these variables should suit most use cases, particularly when first getting up and running, and will only need to be changed in specific cases. However there are some variables that are required to be set by each user as they will be unique to that setup. These are listed in the order they appear in the values.yaml file:
 
 **global.dockerRegistry:** This is the address of your docker registry, where all your images should be stored.
@@ -41,11 +41,15 @@ Most, if not all of the variables you need to set are defined in values.yaml. Th
 
 **mysql.imageTag:**  The version of the MySQL database. This is used to configure the tables in the database. This must match the version of MySQL you have configured.
 
+**mysql.existingSecret:**  The name of a Secret that contains the key 'mysql-password'. The value is the password to use for the mysql.username user. If this is set it will override 'mysql.password'.
+
+**mysql.init:**  If this is 'true' it will run the db-create job. This is required to create the tables in a new db or to reset a db. The default value is 'false'.
+
 **emtDeployment.enabled:** Enabling this allows a user to deploy a FED to a running image. WARNING: This is designed only to be used for testing, never for production. If the container restarts for any reason it will revert to the FED the image was built with.
 
 **cassandra.host0:** The address of the hosts in your cassandra cluster. These must match the port configured in your FED.
 
-###anm
+### anm
 This directory contains all the manifest files related to the Admin Node Manager.
 
 **anm-deployment:** This is defines the anm container. On deployment, this is the first container to start up. If MySQL is enabled, it will validate the database connection is working before starting. If MySQL is not enabled this container will start up straight away.
@@ -54,7 +58,7 @@ This directory contains all the manifest files related to the Admin Node Manager
 
 **anm-service-ext:** This service is used to expose the the container externally. There are different options, depending on your needs: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 
-###apimgmt
+### apimgmt
 This directory contains all the manifest files related to the API Manager UI. This pod handles no Gateway Traffic. We use a separate pod due to the stickiness requirement of the UI.
 
 **apimgmt-statefulset:** This is defines the apimgmt container. On deployment, this container will wait for the anm container to be ready as well as ensuring all cassandra hosts are available before initializing. It will also validate MySQL in the same way the anm container will, if enabled.
@@ -63,7 +67,7 @@ This directory contains all the manifest files related to the API Manager UI. Th
 
 **apimgmt-service-ext:** This service is used to expose the the container externally. There are different options, depending on your needs: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 
-###apimgr
+### apimgr
 This directory contains all the manifest files related to the API Gateway. These pods handle all Gateway Traffic. We run 3 by default, but this can be scaled as needed
 
 **apimgr-deployment:** This is defines the apimgr container. On deployment, this container will wait for the anm and apimgmt containers to be ready as well as ensuring all cassandra hosts are available before initializing. It will also validate MySQL in the same way the anm container will, if enabled.
@@ -72,19 +76,19 @@ This directory contains all the manifest files related to the API Gateway. These
 
 **apimgr-service-ext:** This service is used to expose the the container externally. There are different options, depending on your needs: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 
-###apimgr-oauth
+### apimgr-oauth
 This directory contains the manifest file for the API Gateway Oauth service. This will only work if Oauth is configured in the FED. 
 
 **apimgrOauth--service-ext:** This service is used to expose the the container externally. There are different options, depending on your needs: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 
-###mysql
+### mysql
 This directory contains files used to configure the MySQL database, if enabled. The database must be configured before hand.
 
 **db-create.yaml:** This Job is used to connect to the database and create the required tables using the configuration defined in the configmap. If MySQL is enabled but the database is not available on the host provided in the values.yaml file, this job will fail.
 
 **mysql-configmap-analytics.yaml:** The configuation used to populate the database in the above Job.
 
-##Deployment
+## Deployment
 Once the chart is configured and ready to deploy, the namespace to deploy into must first configured. This namespace needs to match what is configured in values.yaml.
 
 `kubectl create namespace "<NAMESPACE>"`
@@ -108,7 +112,7 @@ Another values.yaml can also be created with a subset of the values from the def
 
 `helm install ./apimgr -f dev-environment-values.yaml`
 
-###Validate
+### Validate
 Configure port-forwarding for all services
 
 ```kubectl port-forward svc/anm-ext 8090:8090

--- a/apimgr/templates/mysql/db-create.yaml
+++ b/apimgr/templates/mysql/db-create.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.mysql.enabled true }}
+{{- if and (eq .Values.mysql.enabled true) (eq .Values.mysql.init true) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -17,10 +17,20 @@ spec:
       - "sh" 
       - "-c" 
       args:
-      - "SQL_COMMANDS=$(cat /tmp/mysql/analytics.sql); mysql -u{{ .Values.mysql.username }} -p{{ .Values.mysql.password }} {{ .Values.mysql.databaseName }} -h {{ .Values.mysql.hostname }} -e \"${SQL_COMMANDS} \""
+      - "SQL_COMMANDS=$(cat /tmp/mysql/analytics.sql); mysql -u{{ .Values.mysql.username }} -p${MYSQL_PASSWORD} {{ .Values.mysql.databaseName }} -h {{ .Values.mysql.hostname }} -e \"${SQL_COMMANDS} \""
       volumeMounts:
       - name: config-volume
         mountPath: /tmp/mysql
+      env:
+      - name: MYSQL_PASSWORD
+      {{- if ne .Values.mysql.existingSecret "" }}
+        valueFrom:
+          secretKeyRef:
+            key: mysql-password
+            name: {{ .Values.mysql.existingSecret }}
+      {{ else }}
+        value: {{ .Values.mysql.password }}
+      {{- end }}
    volumes:
     - name: config-volume
       configMap:

--- a/apimgr/values.yaml
+++ b/apimgr/values.yaml
@@ -100,6 +100,10 @@ mysql:
   imageName: "mysql"
   # version of mysql your database is running
   imageTag: "5.7"
+  # A secret that contains the password for the mysql instance Key = mysql-password
+  existingSecret: ""
+  # Only run migrations if needed
+  init: false
 
 # Enable ability to deploy a FED to a running environment
 # WARNING: Should only be used for test environments, Never for production


### PR DESCRIPTION
I added the ability to have a predefined secret for the password to connect to the mysql database.This way there is no password in plain text in the values.yaml file. I also added mysql.init to the values.yaml file which when set to 'true' runs the db-create-mysql-apigw job when set to 'false' the job will not be created. This allows all metric data to persist between deployments of the gateway.